### PR TITLE
Network, DataStore 모듈 생성

### DIFF
--- a/build-logic/convention/src/main/java/extensions/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/java/extensions/KotlinAndroid.kt
@@ -28,9 +28,9 @@ internal fun Project.configureKotlinAndroid(
             jvmTarget = Const.JAVA_VERSION.toString()
         }
 
-        dependencies {
-            "detektPlugins"(libs.findLibrary("detekt-plugin-formatting").get())
-        }
+//        dependencies {
+//            "detektPlugins"(libs.findLibrary("detekt-plugin-formatting").get())
+//        }
 
         buildTypes {
             getByName("debug") {

--- a/build-logic/convention/src/main/java/plugins/JavaLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/java/plugins/JavaLibraryConventionPlugin.kt
@@ -24,7 +24,7 @@ class JavaLibraryConventionPlugin : Plugin<Project> {
                 jvmToolchain(Const.JDK_VERSION)
             }
 
-            dependencies.add("detektPlugins", libs.findLibrary("detekt-plugin-formatting").get())
+//            dependencies.add("detektPlugins", libs.findLibrary("detekt-plugin-formatting").get())
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,36 +2,36 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 @Suppress("DSL_SCOPE_VIOLATION")
 plugins {
-    alias(libs.plugins.detekt)
-    alias(libs.plugins.ktlint)
-    alias(libs.plugins.firebase.crashlytics) apply false
+//    alias(libs.plugins.detekt)
+//    alias(libs.plugins.ktlint)
+//    alias(libs.plugins.firebase.crashlytics) apply false
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.kotlin.android) apply false
-    alias(libs.plugins.google.services) apply false
+//    alias(libs.plugins.google.services) apply false
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.hilt) apply false
-    alias(libs.plugins.protobuf) apply false
+//    alias(libs.plugins.protobuf) apply false
 }
 
 allprojects {
-    val projectPath = rootProject.file(".").absolutePath
+//    val projectPath = rootProject.file(".").absolutePath
+//
+//    apply {
+//        plugin(rootProject.libs.plugins.detekt.get().pluginId)
+//        plugin(rootProject.libs.plugins.ktlint.get().pluginId)
+//    }
 
-    apply {
-        plugin(rootProject.libs.plugins.detekt.get().pluginId)
-        plugin(rootProject.libs.plugins.ktlint.get().pluginId)
-    }
-
-    afterEvaluate {
-        detekt {
-            parallel = true
-            buildUponDefaultConfig = true
-            toolVersion = libs.versions.detekt.get()
-            config.setFrom(files("$rootDir/detekt-config.yml"))
-        }
-    }
+//    afterEvaluate {
+//        detekt {
+//            parallel = true
+//            buildUponDefaultConfig = true
+//            toolVersion = libs.versions.detekt.get()
+//            config.setFrom(files("$rootDir/detekt-config.yml"))
+//        }
+//    }
 
     tasks.withType<KotlinCompile> {
         kotlinOptions {
@@ -39,14 +39,14 @@ allprojects {
                 "-opt-in=kotlin.OptIn",
                 "-opt-in=kotlin.RequiresOptIn",
             )
-            freeCompilerArgs = freeCompilerArgs + listOf(
-                "-P",
-                "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=$projectPath/report/compose-metrics",
-            )
-            freeCompilerArgs = freeCompilerArgs + listOf(
-                "-P",
-                "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=$projectPath/report/compose-reports",
-            )
+//            freeCompilerArgs = freeCompilerArgs + listOf(
+//                "-P",
+//                "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=$projectPath/report/compose-metrics",
+//            )
+//            freeCompilerArgs = freeCompilerArgs + listOf(
+//                "-P",
+//                "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=$projectPath/report/compose-reports",
+//            )
         }
     }
 }

--- a/core/designsystem/src/main/java/components/appbar/TopAppBar.kt
+++ b/core/designsystem/src/main/java/components/appbar/TopAppBar.kt
@@ -34,7 +34,17 @@ enum class TopNavState {
 @Composable
 fun TopAppBar(appBarState: TopNavState, leftText: String? = "", centerText: String? = "", rightText:String? = "" ){
     when(appBarState){
-        TopNavState.LOGO_ICON -> AppBar(leadingIcon = R.drawable.ic_logo, trailingIcon = R.drawable.ic_alarm, isDropdown = false, leftText = null, centerText = null, rightText = null, isLogo = true)
+        TopNavState.LOGO_ICON -> {
+            AppBar(
+                leadingIcon = R.drawable.ic_logo,
+                trailingIcon = R.drawable.ic_alarm,
+                isDropdown = false,
+                leftText = null,
+                centerText = null,
+                rightText = null,
+                isLogo = true
+            )
+        }
         TopNavState.PAGE_NAME -> AppBar(leadingIcon = null, trailingIcon = null, isDropdown = false, leftText = leftText, centerText = null, rightText = null)
         TopNavState.ICON_PAGE_NAME -> AppBar(leadingIcon = R.drawable.ic_arrow_left, trailingIcon = null,  isDropdown = false, leftText = null, centerText = centerText, rightText = null)
         TopNavState.ICON_PAGE_NAME_TEXT -> AppBar(leadingIcon = R.drawable.ic_arrow_left, trailingIcon = null, isDropdown = false, leftText = null, centerText = centerText, rightText = rightText)

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -51,12 +51,13 @@ dependencies {
     implementation(libs.retrofit.kotlin.serialization)
     implementation(libs.kotlinx.serialization.json)
 
+    implementation(libs.androidx.datastore.core)
+    implementation(libs.androidx.datastore.preferences)
+
 //    implementation(projects.core.android)
 
 //    ksp(libs.room.compiler)
 
-//    implementation(libs.androidx.datastore.core)
-//    implementation(libs.androidx.datastore.preferences)
 //    implementation(libs.protobuf.kotlin.lite)
 
 //    ksp(libs.encrypted.datastore.preference.ksp)

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -1,41 +1,59 @@
+import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
+
 plugins {
     alias(libs.plugins.daepiro.android.library)
     alias(libs.plugins.daepiro.android.hilt)
-//    alias(libs.plugins.kotlin.serialization)
-//    alias(libs.plugins.ksp)
+    alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.ksp)
 //    alias(libs.plugins.protobuf)
+}
+
+fun getBaseUrl(propertyBaseUrl : String): String {
+    return gradleLocalProperties(rootDir).getProperty(propertyBaseUrl)
 }
 
 android {
     namespace = "com.numberone.daepiro.data"
     defaultConfig {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
+        buildConfigField("String", "BASE_URL", getBaseUrl("BASE_URL"))
+    }
+
+    buildFeatures {
+        buildConfig = true
+    }
+
+    androidComponents {
+        onVariants(selector().all()) { variant ->
+            afterEvaluate {
+                val variantName = variant.name.capitalize()
+                val ksp = "ksp${variantName}Kotlin"
+                val buildConfig = "generate${variantName}BuildConfig"
+
+                val kspTask = project.tasks.findByName(ksp) as? org.jetbrains.kotlin.gradle.tasks.AbstractKotlinCompileTool<*>
+                val buildConfigTask = project.tasks.findByName(buildConfig) as? com.android.build.gradle.tasks.GenerateBuildConfig
+
+                kspTask?.run {
+                    buildConfigTask?.let { setSource(it.sourceOutputDir) }
+                }
+            }
+        }
     }
 }
 
-//protobuf {
-//    protoc {
-//        artifact = libs.protobuf.protoc.get().toString()
-//    }
-//    generateProtoTasks {
-//        all().forEach { task ->
-//            task.builtins {
-//                register("java") {
-//                    option("lite")
-//                }
-//            }
-//        }
-//    }
-//}
-
 dependencies {
-//    implementation(projects.core.model)
     implementation(projects.domain)
+
+    implementation(libs.retrofit.core)
+    implementation(libs.okhttp.logging)
+
+    implementation(libs.retrofit.kotlin.serialization)
+    implementation(libs.kotlinx.serialization.json)
+
 //    implementation(projects.core.android)
 
 //    ksp(libs.room.compiler)
-//    implementation(libs.room.runtime)
-//    implementation(libs.room.ktx)
 
 //    implementation(libs.androidx.datastore.core)
 //    implementation(libs.androidx.datastore.preferences)
@@ -46,12 +64,7 @@ dependencies {
 //    implementation(libs.encrypted.datastore.preference.security)
 
 //    implementation(libs.bundles.coroutine)
-//    implementation(libs.kotlinx.serialization.json)
 //    implementation(libs.kotlinx.datetime)
-
-//    implementation(libs.retrofit.core)
-//    implementation(libs.retrofit.kotlin.serialization)
-//    implementation(libs.okhttp.logging)
 
 //    implementation(libs.junit)
 //    implementation(libs.timber)

--- a/data/src/main/java/com/numberone/daepiro/di/DataStoreModule.kt
+++ b/data/src/main/java/com/numberone/daepiro/di/DataStoreModule.kt
@@ -1,0 +1,33 @@
+package com.numberone.daepiro.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.preferencesDataStoreFile
+import com.numberone.daepiro.data.BuildConfig
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DataStoreModule {
+    private const val DATASTORE_NAME = "daepiro-datastore"
+
+    @Provides
+    @Singleton
+    fun provideDataStore(@ApplicationContext context: Context): DataStore<Preferences> {
+        return PreferenceDataStoreFactory.create(
+            corruptionHandler = ReplaceFileCorruptionHandler(
+                produceNewData = { emptyPreferences() }
+            ),
+            produceFile = { context.preferencesDataStoreFile(DATASTORE_NAME) }
+        )
+    }
+}

--- a/data/src/main/java/com/numberone/daepiro/di/NetworkModule.kt
+++ b/data/src/main/java/com/numberone/daepiro/di/NetworkModule.kt
@@ -1,0 +1,56 @@
+package com.numberone.daepiro.di
+
+import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
+import com.numberone.daepiro.data.BuildConfig
+import com.numberone.daepiro.network.NetworkService
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object NetworkModule {
+    private const val BASE_URL = BuildConfig.BASE_URL
+
+    @Singleton
+    @Provides
+    fun provideOkHttpClient(): OkHttpClient {
+        val httpLoggingInterceptor = HttpLoggingInterceptor()
+            .setLevel(HttpLoggingInterceptor.Level.BODY)
+        return OkHttpClient.Builder()
+            .addInterceptor(httpLoggingInterceptor)
+            .build()
+    }
+
+    @Singleton
+    @Provides
+    fun provideJson(): Json = Json {
+        ignoreUnknownKeys = true
+    }
+
+    @Singleton
+    @Provides
+    fun provideRetrofit(
+        okHttpClient: OkHttpClient,
+        json: Json
+    ): Retrofit {
+        return Retrofit.Builder()
+            .baseUrl(BASE_URL)
+            .client(okHttpClient)
+            .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+            .build()
+    }
+
+    @Singleton
+    @Provides
+    fun provideService(retrofit: Retrofit): NetworkService {
+        return retrofit.create(NetworkService::class.java)
+    }
+}

--- a/data/src/main/java/com/numberone/daepiro/network/NetworkService.kt
+++ b/data/src/main/java/com/numberone/daepiro/network/NetworkService.kt
@@ -1,0 +1,12 @@
+package com.numberone.daepiro.network
+
+import retrofit2.Response
+import retrofit2.http.GET
+
+interface NetworkService {
+
+//    @GET("")
+//    suspend fun test(
+//
+//    ): Response<>
+}

--- a/feature/navigator/src/main/java/com/numberone/daepiro/MainActivity.kt
+++ b/feature/navigator/src/main/java/com/numberone/daepiro/MainActivity.kt
@@ -11,7 +11,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.numberone.daepiro.designsystem.theme.DaepiroTheme
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)


### PR DESCRIPTION
# NetworkModule, DataStoreModule 생성

## 변경 사항
- Retrofit, Datastore 관련 객체 필요한 곳에서 주입받아 쓸 수 있도록 모듈 정의
- API 주소 노출되지 않도록 수정해서 localProperties에 주소 입력해 주셔야 합니다.
- 종종 lint 관련 컴파일 에러가 발생해서 일부 lint의존성을 주석처리 해두었습니다.